### PR TITLE
ci: update container image

### DIFF
--- a/.github/workflows/push-website.yml
+++ b/.github/workflows/push-website.yml
@@ -1,7 +1,7 @@
 name: push-website
 
 env:
-  image_tag: 25f5ba433591
+  image_tag: 946a6a37ed67
 
 on:
   push:

--- a/nix/ci/flake.lock
+++ b/nix/ci/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1649225869,
-        "narHash": "sha256-u1zLtPmQzhT9mNXyM8Ey9pk7orDrIKdwooeGDEXm5xM=",
+        "lastModified": 1657693803,
+        "narHash": "sha256-G++2CJ9u0E7NNTAi9n5G8TdDmGJXcIjkJ3NF8cetQB8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b6966d911da89e5a7301aaef8b4f0a44c77e103c",
+        "rev": "365e1b3a859281cf11b94f87231adeabbdd878a2",
         "type": "github"
       },
       "original": {
         "id": "nixpkgs",
-        "ref": "nixos-unstable",
+        "ref": "nixos-22.05",
         "type": "indirect"
       }
     },

--- a/nix/ci/flake.nix
+++ b/nix/ci/flake.nix
@@ -1,7 +1,7 @@
 {
   description = "fdb-rs website flake";
 
-  inputs.nixpkgs.url = "nixpkgs/nixos-unstable";
+  inputs.nixpkgs.url = "nixpkgs/nixos-22.05";
 
   outputs = { self, nixpkgs }: {
     website =
@@ -71,6 +71,8 @@
 
           mkdir -p /home/runner/website
           chown -R runner:docker /home/runner
+
+          mkdir -p /nix/var/nix/daemon-socket
 
           systemctl enable nix-daemon.socket
         '';


### PR DESCRIPTION
Update container image to NixOS release 22.05.

In NixOS 22.05 release, for some reason `/nix/var/nix/daemon-socket`
directory is not being created. So manually create this path so that
systemd's `nix-daemon.socket` can be properly started.